### PR TITLE
Strongly type input and return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Currently our best examples are in the test folder.
 
   try {
     // We can now request the index from cap1 on cap2:
-    const remoteApi: any = await cap2.requestIndex(remote2);
+    const remoteApi: IAsyncApiValue = await cap2.requestIndex(remote2);
 
     // Notice they are not the same objects:
     t.notEqual(remoteApi, api, 'Api objects are not the same object.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capnode",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A JS promise-based capabilities system over any stream.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,10 +1,21 @@
 import { MethodRegistry } from "../method-registry";
+import { SerializedFormat } from "../serializers/default";
 
-export type IAsyncApiObject = { [key: string]: IAsyncApiValue };
-export type IPrimitiveValue = string | number | boolean | undefined;
-export type IAsyncAbstractValue = IAsyncApiObject | IAsyncFunction | IPrimitiveValue;
-export type IAsyncApiValue = IAsyncApiObject | IAsyncFunction | IPrimitiveValue | Array<IAsyncAbstractValue>;
-export type IAsyncFunction = (...args: any[]) => Promise<any>;
+export type IAsyncFunction = (...args: IApiValue[]) => Promise<IApiValue>;
+export interface IAsyncApiObject {
+    [key: string]:  IAsyncApiValue,
+}
+export interface IAsyncArray extends Array<IAsyncApiValue> {}
+export type IPrimitiveValue = string | number | boolean | undefined | void;
+export type IAsyncApiValue = IAsyncApiObject | IAsyncFunction | IPrimitiveValue | IAsyncArray;
+
+
+export interface IApiArray extends Array<IApiValue> {}
+export interface IApiObject {
+    [key: string]:  IApiValue,
+};
+export type IApiValue = IApiObject | Function | IPrimitiveValue | IApiArray;
+
 export interface IRemoteFunction extends IAsyncFunction {
   dealloc: Function;
 }
@@ -17,7 +28,7 @@ export type ICapnodeMessage = IInvocationMessage | IIndexMessage | IErrorMessage
 export type ICapnodeMessageAbstract = {
   type: 'index' | 'invocation' | 'error' | 'return' | 'dealloc';
   value?: any;
-  arguments?: ISerializedAsyncApiObject[];
+  arguments?: SerializedFormat;
   methodId?: string;
   replyId?: string;
 };
@@ -41,6 +52,6 @@ export interface IDeallocMessage extends ICapnodeMessageAbstract {
 export type ISerializedAsyncApiObject = string | number | boolean | object | Array<any> | undefined;
 
 export interface ICapnodeSerializer {
-  serialize: (message: IAsyncApiValue, registry: MethodRegistry) => any;
+  serialize: (message: IApiValue, registry: MethodRegistry) => unknown;
   deserialize: (data: any, registry: MethodRegistry, sendMessage: ICapnodeMessageSender) => IAsyncApiValue;
 }

--- a/src/cap-wrap.ts
+++ b/src/cap-wrap.ts
@@ -1,7 +1,7 @@
-import { IAsyncApiValue } from "./@types";
+import { IAsyncApiValue, IApiValue } from "./@types";
 import Capnode from '../';
 
-export default async function capWrap (api: IAsyncApiValue): Promise<IAsyncApiValue> {
+export default async function capWrap (api: IApiValue): Promise<IAsyncApiValue> {
   const cap = new Capnode({ index: api });
   const cap2 = new Capnode({});
   const remote = cap.createRemote();

--- a/src/method-registry/index.ts
+++ b/src/method-registry/index.ts
@@ -1,6 +1,3 @@
-import {
-  IAsyncFunction,
-} from '../@types/index';
 const cryptoRandomString = require('crypto-random-string');
 const k_BYTES_OF_ENTROPY = 20
 
@@ -10,20 +7,20 @@ type IResolver = {
 }
 
 export class MethodRegistry {
-  private indexFuncs: Set<IAsyncFunction> = new Set();
-  private methodMap: Map<string, IAsyncFunction> = new Map();
-  private reverseMap: Map<IAsyncFunction, string> = new Map();
+  private indexFuncs: Set<Function> = new Set();
+  private methodMap: Map<string, Function> = new Map();
+  private reverseMap: Map<Function, string> = new Map();
   public pendingPromises: Map<string, IResolver> = new Map();
 
-  protectFunction (method: IAsyncFunction) {
+  protectFunction (method: Function) {
     this.indexFuncs.add(method);
   }
 
-  unprotectFunction (method: IAsyncFunction) {
+  unprotectFunction (method: Function) {
     this.indexFuncs.delete(method);
   }
 
-  registerFunction (method: IAsyncFunction): string {
+  registerFunction (method: Function): string {
     const oldId = this.reverseMap.get(method);
     if (oldId && typeof oldId === 'string') {
       this.methodMap.set(oldId, method);
@@ -37,7 +34,7 @@ export class MethodRegistry {
     return id;
   }
 
-  getFunction (methodId: string): IAsyncFunction | undefined {
+  getFunction (methodId: string): Function | undefined {
     return this.methodMap.get(methodId);
   }
 
@@ -53,7 +50,7 @@ export class MethodRegistry {
     }
   }
 
-  getId (method: IAsyncFunction): string | undefined { 
+  getId (method: Function): string | undefined { 
     return this.reverseMap.get(method);
   }
 

--- a/src/serializers/default.test.ts
+++ b/src/serializers/default.test.ts
@@ -16,13 +16,22 @@ test('serializes and deserializes circular objects', (t) => {
   const serialized = serializer.serialize(input, registry);
   const output = serializer.deserialize(serialized, registry, noop);
 
+  if (typeof output !== 'object') {
+    t.fail('output should be an object');
+    return t.end();
+  }
+
   t.notEqual(input, serialized);
   t.equal(Object.keys(input)[0], Object.keys(output)[0]);
   t.ok(input && input.y && input.y.x);
- if (input && input.y && input.y.x) {
+  if (input && input.y && input.y.x
+      && ('y' in output)  && typeof output.y === 'object' && ('x' in output.y) && typeof output.y.x === 'object'
+    ) {
+
     t.equal(Object.keys(input.y.x)[0], Object.keys(output.y.x)[0]);
   } else {
     t.fail();
+    return t.end();
   }
 
   t.equal(input, input.y.x);

--- a/src/serializers/default.test.ts
+++ b/src/serializers/default.test.ts
@@ -2,7 +2,7 @@ import test from 'tape';
 import DefaultSerializer from './default';
 import { MethodRegistry } from '../method-registry';
 
-// require ('../serializers/default.test');
+// TODO: Add a circular array test.
 
 test('serializes and deserializes circular objects', (t) => {
   const serializer = new DefaultSerializer();

--- a/src/serializers/default.test.ts
+++ b/src/serializers/default.test.ts
@@ -30,7 +30,7 @@ test('serializes and deserializes circular objects', (t) => {
 
     t.equal(Object.keys(input.y.x)[0], Object.keys(output.y.x)[0]);
   } else {
-    t.fail();
+    t.fail('output lacked expected keys');
     return t.end();
   }
 

--- a/src/serializers/default.ts
+++ b/src/serializers/default.ts
@@ -262,14 +262,11 @@ export default class DefaultSerializer {
 
           Object.keys(serialized).forEach((key:string) => {
             const val:IDefaultSerializedLeaf = serialized[key];
-            const leaf = this.deserializeLeaf(val, registry, sendMessage, meta);
-            if (leaf && typeof leaf === 'function') {
-              ret[key] = leaf;
-            }
+            ret[key] = this.deserializeLeaf(val, registry, sendMessage, meta);
           })
         }
-        return meta.reconstructed[id];
 
+      return meta.reconstructed[id];
     }
 
     throw new Error('deserializeObject called with invalid data ' + data);

--- a/test/capWrap.ts
+++ b/test/capWrap.ts
@@ -236,7 +236,7 @@ test('remote deallocation', async (t) => {
   remote2.addRemoteMessageListener((message) => remote.receiveMessage(message));
 
   try {
-    const remoteApi: any = await cap2.requestIndex(remote2);
+    const remoteApi: IAsyncApiValue = await cap2.requestIndex(remote2);
 
     const listeners: IRemoteFunction[] = [];
     const emitter = {
@@ -257,6 +257,10 @@ test('remote deallocation', async (t) => {
       }
     };
 
+    if (!('receiveEvents' in remoteApi) || typeof remoteApi['receiveEvents'] !== 'function') {
+      t.fail('remote api lacked subscription method')
+      return t.end()
+    }
     await remoteApi.receiveEvents(emitter);
 
   } catch (err) {
@@ -266,4 +270,10 @@ test('remote deallocation', async (t) => {
   t.end();
 })
 
-
+test('makes functions async', async (t) => {
+    const EXPECTED = 'Hello!'
+    const func = () => EXPECTED
+    const func2 = await capWrap(func);
+    const result = await func2();
+    t.equal(result, EXPECTED, 'Made function async.')
+})

--- a/test/capWrap.ts
+++ b/test/capWrap.ts
@@ -24,7 +24,8 @@ test('basic serialization and api reconstruction', async (t) => {
     t.notEqual(remoteApi, api, 'Api objects are not the same object.');
 
     if (typeof remoteApi !== 'object' || Array.isArray(remoteApi)) {
-      return t.fail('did not return an object');
+      t.fail('did not return an object');
+      return t.end();
     }
 
     // They do, however, share the same properties and tyeps:
@@ -32,17 +33,20 @@ test('basic serialization and api reconstruction', async (t) => {
       t.ok(key in api, 'The original api has the key ' + key);
 
       if (typeof remoteApi !== 'object') {
-        return t.fail('did not return an object');
+        t.fail('did not return an object');
+        return t.end();
       }
 
       if (typeof key !== 'string') {
-        return t.fail('key was not a string');
+        t.fail('key was not a string');
+        return t.end();
       }
 
       if (!(key in api) || !api[key]
         || !(key in remoteApi) || !remoteApi[key]
       ) {
-        return t.fail(`Key ${key} was not found in returned api`);
+        t.fail(`Key ${key} was not found in returned api`);
+        return t.end();
       }
 
       t.equal(typeof remoteApi[key], typeof api[key], 'The values are the same type');
@@ -54,7 +58,8 @@ test('basic serialization and api reconstruction', async (t) => {
     })
 
     if (!remoteApi.baz || typeof remoteApi.baz !== 'function') {
-      return t.fail('baz was not a function');
+      t.fail('baz was not a function');
+      return t.end();
     }
 
     // We can even call the functions provided:
@@ -65,7 +70,7 @@ test('basic serialization and api reconstruction', async (t) => {
     t.error(err);
   }
 
-  t.end();
+  return t.end();
 })
 
 test('creating an event emitter', async (t) => {
@@ -114,7 +119,7 @@ test('creating an event emitter', async (t) => {
     // We can even call the functions provided:
     const result = await remoteApi.subscribe(async (result: IAsyncApiValue) => {
       t.equal(result, 'foo', 'The subscription was fired.');
-      t.end();
+      return t.end();
     });
     t.equal(result, 'OKAY!', 'the result was returned');
 
@@ -170,7 +175,7 @@ test('passing event emitters around', async (t) => {
     // We can even call the functions provided:
     const result = await remoteApi.subscribe(async (result: IAsyncApiValue) => {
       t.equal(result, 'foo', 'The subscription was fired.');
-      t.end();
+      return t.end();
     });
     t.equal(result, 'OKAY!', 'the result was returned');
 
@@ -191,7 +196,7 @@ test('passing functions back and forth', async (t) => {
           value: 'very well, and you?',
           reply: async (theirState: string) => {
             t.equal(theirState, 'jolly well indeed.');
-            t.end();
+            return t.end();
           }
         }
       }
@@ -240,7 +245,8 @@ test('remote deallocation', async (t) => {
 
       if (!emitter || typeof emitter !== 'object' || !('on' in emitter)
       || !emitter.on || typeof emitter.on !== 'function') {
-        return t.fail('emitter was malformed');
+        t.fail('emitter was malformed');
+        return t.end();
       }
 
       // The emitter side is going to tell this side to deallocate:
@@ -295,7 +301,7 @@ test('remote deallocation', async (t) => {
     t.error(err);
   }
 
-  t.end();
+  return t.end();
 })
 
 test('makes functions async', async (t) => {
@@ -306,7 +312,8 @@ test('makes functions async', async (t) => {
     if (func2 && typeof func2 === 'function') {
       func2 = func2 as IAsyncFunction;
     } else {
-      return t.fail('func2 was malformed');
+      t.fail('func2 was malformed');
+      return t.end();
     }
 
     const result = await func2();

--- a/test/capWrap.ts
+++ b/test/capWrap.ts
@@ -42,8 +42,8 @@ test('basic serialization and api reconstruction', async (t) => {
         return t.end();
       }
 
-      if (!(key in api) || !api[key]
-        || !(key in remoteApi) || !remoteApi[key]
+      if (!(key in api)
+        || !(key in remoteApi)
       ) {
         t.fail(`Key ${key} was not found in returned api`);
         return t.end();
@@ -305,17 +305,23 @@ test('remote deallocation', async (t) => {
 })
 
 test('makes functions async', async (t) => {
-    const EXPECTED = 'Hello!'
-    const func = () => EXPECTED
-    let func2: IAsyncApiValue = await capWrap(func);
+  const EXPECTED = 'Hello!'
+  const func = () => EXPECTED
+  console.log('wrapping')
+  let func2: IAsyncApiValue = await capWrap(func);
+  console.log('wrapped')
 
-    if (func2 && typeof func2 === 'function') {
-      func2 = func2 as IAsyncFunction;
-    } else {
-      t.fail('func2 was malformed');
-      return t.end();
-    }
+  if (func2 && typeof func2 === 'function') {
+    func2 = func2 as IAsyncFunction;
+  } else {
+    t.fail('func2 was malformed'); 
+    return t.end();
+  }
 
-    const result = await func2();
-    t.equal(result, EXPECTED, 'Made function async.')
+  const result = await func2();
+  t.equal(result, EXPECTED, 'Made function async.')
+  const result2 = func2();
+  t.notEqual(result2, EXPECTED, 'returns a promise');
+  t.ok(result2 instanceof Promise, 'is a promise');
+  t.end();
 })

--- a/test/capWrap.ts
+++ b/test/capWrap.ts
@@ -10,7 +10,7 @@ test('basic serialization and api reconstruction', async (t) => {
    * The API we want to make available over a serializable async boundary
    * like a network, process, or other context:
    */
-  const api: IAsyncApiObject = {
+  const api: IApiObject = {
     foo: 'bar',
     baz: async () => 'bam',
     bork: undefined,


### PR DESCRIPTION
Previously I had over-relied on the `any` type. Now the input and output use the `IAPIValue` and `IAsyncApiValue` types.

You can see basic usage here:
```typescript
  const api: IApiObject = {
    foo: 'bar',
    baz: async () => 'bam',
    bork: undefined,
  }

  const remoteApi: IAsyncApiValue = await capWrap(api);
```

The difference in these types is that `IApiValue` can include synchronous functions, but they are all converted to promise-returning functions for the sake of exposing to a remote, hence `IAsyncApiValue`.