### PR TITLE
Correct entropy usage

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -253,5 +253,5 @@ export default class Capnode {
 }
 
 function random () {
-  return cryptoRandomString(k_BYTES_OF_ENTROPY)
+  return cryptoRandomString(k_BYTES_OF_ENTROPY * 2)
 }


### PR DESCRIPTION
We generated a number of characters instead of bytes (which are two characters), and so the entropy bytes constant now correctly defines the desired amount of entropy.