### PR TITLE
Add restorable methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # CapNode [![CircleCI](https://circleci.com/gh/danfinlay/capnode.svg?style=svg)](https://circleci.com/gh/danfinlay/capnode)
 
-Sharing objects and their methods over a JSON transport as easy as passing around the JS Objects themselves. [Sometimes called](http://blog.ezyang.com/2013/03/what-is-a-membran/) remote proxy objects.
-
-Very much inspired by [dnode](https://www.npmjs.com/package/dnode), but intended to be extended in a few different directions.
-
-Created to make it especially easy for developers to very intuitively create externally consumable APIs.
+Sharing objects and their promise-returning methods over a JSON transport (nearly) as easy as passing around the JS Objects themselves. [Sometimes called](http://blog.ezyang.com/2013/03/what-is-a-membran/) remote proxy objects.
 
 ## Status
 
-Very early WIP, needs thorough audit and QA.
+Version `4.0.2` underwent a security audit, but is continuing under some active development in new potentially dangerous directions:
+- One client of a host can now pass its method access to another client.
 
 External APIs are pretty simple, so they may be stable, but until [we](https://metamask.io/) are using it in production, I will probably break APIs freely.
 
@@ -85,6 +82,32 @@ connect()
 .then(console.log)
 .catch(console.error)
 
+```
+
+### Delegation Example
+
+Every remote function returned from capnode has an id, and you can use this to pass access control over a function from one client to another.
+
+For example, accessing the method Id from client 1:
+
+```typescript
+const remoteApi: any = await client1.requestIndex(clientRemote1);
+
+const baz: IRemoteAsyncMethod = remoteApi.baz;
+const bazId = baz.capId;
+```
+
+If we assume that `bazId` is now transmitted to another client who has their own `remote` connected to the host, they can construct a method from that Id alone:
+
+```typescript
+const baz2 = clientRemote2.reconstruct(bazId);
+
+// Notice they are not the same objects:
+t.notEqual(baz, baz2, 'Api objects are not the same object.');
+
+// We should be able to normally call reconstructed objects:
+const result = await baz2();
+t.equal(result, 'bam');
 ```
 
 ### Test Example:

--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ export default class Capnode {
   createRemote(): Remote {
     const remote = new Remote((message: ICapnodeMessage) => {
       this.processMessage(message, remote);
-    });
+    }, this.registry, this.serializer);
     this.remotes.add(remote);
     return remote;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "capnode",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,5 +1,6 @@
 import { MethodRegistry } from "../method-registry";
-import { SerializedFormat } from "../serializers/default";
+import { SerializedFormat, IRemoteAsyncMethod } from "../serializers/default";
+export { IRemoteAsyncMethod } from "../serializers/default";
 
 export type IAsyncFunction = (...args: IApiValue[]) => Promise<IApiValue>;
 export interface IAsyncApiObject {
@@ -54,4 +55,5 @@ export type ISerializedAsyncApiObject = string | number | boolean | object | Arr
 export interface ICapnodeSerializer {
   serialize: (message: IApiValue, registry: MethodRegistry) => unknown;
   deserialize: (data: any, registry: MethodRegistry, sendMessage: ICapnodeMessageSender) => IAsyncApiValue;
+  deserializeFunction: (methodId: string, registry: MethodRegistry, sendMessage: ICapnodeMessageSender) => IRemoteAsyncMethod; 
 }

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,5 +1,11 @@
-import { ICapnodeMessageSender, ICapnodeMessage } from "./@types";
+import { ICapnodeMessageSender, ICapnodeMessage, ICapnodeSerializer } from "./@types";
 import { Duplex } from 'stream';
+import { IRemoteAsyncMethod } from './serializers/default';
+import { MethodRegistry } from "./method-registry";
+
+interface IRemote {
+  emitMessage: ICapnodeMessageSender;
+}
 
 /**
  * The Remote class is used to represent a single connection to a Capnode host.
@@ -9,13 +15,15 @@ import { Duplex } from 'stream';
  * @property messageHandler - The method used by the local capnode instance to send its messages to this remote instance.
  * 
  */
-export default class Remote extends Duplex {
+export default class Remote extends Duplex implements IRemote {
   private localMessageListeners: Set<ICapnodeMessageSender> = new Set();
   private remoteMessageListeners: Set<ICapnodeMessageSender> = new Set();
   private streamReading = true;
   private queue: ICapnodeMessage[] = [];
+  private registry: MethodRegistry | undefined;
+  private serializer: ICapnodeSerializer | undefined;
 
-  constructor(messageHandler?: ICapnodeMessageSender) {
+  constructor(messageHandler?: ICapnodeMessageSender, registry?: MethodRegistry, serializer?: ICapnodeSerializer) {
     super({
       write: (stringMessage: string, _encoding, cb: (err?: Error) => void) => {
         if (!stringMessage) {
@@ -50,6 +58,8 @@ export default class Remote extends Duplex {
     // Connect stream to remote listeners:
     this.sendMessageOverStream = this.sendMessageOverStream.bind(this);
     this.addRemoteMessageListener(this.sendMessageOverStream);
+    this.registry = registry;
+    this.serializer = serializer;
 
     if (messageHandler) {
       this.addLocalMessageListener(messageHandler);
@@ -104,5 +114,18 @@ export default class Remote extends Duplex {
   emitMessage(message: ICapnodeMessage): void {
     if (!message) return;
     this.informAll(this.remoteMessageListeners, message);
+  }
+
+  reconstruct(methodId: string | undefined): IRemoteAsyncMethod {
+    if (methodId === undefined) {
+      throw new Error('Reconstructing a remote method requires a methodId.');
+    }
+
+    if (!this.serializer || !this.registry) {
+      throw new Error('reconstruct requires a serializer and registry.');
+    }
+
+    const func = this.serializer.deserializeFunction(methodId, this.registry, this.emitMessage.bind(this));
+    return func;
   }
 }

--- a/src/serializers/default.ts
+++ b/src/serializers/default.ts
@@ -6,12 +6,13 @@ import {
   IDeallocMessage,
   IApiValue,
   IAsyncArray,
-} from '../@types/index.d';
+} from '../@types/index';
 const cryptoRandomString = require('crypto-random-string');
 const k_BYTES_OF_ENTROPY = 20;
 
-interface IRemoteAsyncMethod extends IAsyncFunction {
+export interface IRemoteAsyncMethod extends IAsyncFunction {
   dealloc?: () => void;
+  capId?: string;
 }
 
 enum LinkableType {
@@ -288,6 +289,7 @@ export default class DefaultSerializer {
 
       });
     };
+    result.capId = methodId;
     result.dealloc = () => {
       return new Promise((res, rej) => {
         const deallocId = random();


### PR DESCRIPTION
Fixes #12 by making it unnecessary:

Rather than preventing method Ids from "overlapping" between client spaces and avoiding reusing the method registry, we can take advantage of the shared registry's [healthy amount of entropy](https://github.com/danfinlay/capnode/blob/a60d117b59240d3a631193419738fe8139c3ca94/index.ts#L22) on the `method id`s, which is so high these are effectively [macaroons](https://research.google/pubs/pub41892/).

This PR makes a small change that:
- Adds the method ID as an accessible property on every capnode-returned method.
- Allows clients to construct fresh functions from a `method id` and a `remote` to its `host`.

This effectively introduces a capability-like delegation system into capnode.